### PR TITLE
Add missing backtick to `placeholder` default example in `docs`

### DIFF
--- a/packages/website/docs/api.mdx
+++ b/packages/website/docs/api.mdx
@@ -59,7 +59,7 @@ Your Algolia index name.
 
 ## `placeholder`
 
-> `type: string` | `default: "Search docs" | **optional**
+> `type: string` | `default: "Search docs"` | **optional**
 
 The placeholder of the input of the DocSearch pop-up modal.
 


### PR DESCRIPTION
Adds a missing backtick and fixes the formatting.